### PR TITLE
Skip sleep

### DIFF
--- a/web/private/scripts/mosaic-quicksilver/deploy_product/fix_race_condition.php
+++ b/web/private/scripts/mosaic-quicksilver/deploy_product/fix_race_condition.php
@@ -5,5 +5,5 @@
  * on the deploy_product "after" stage whereby scripts are started before the container is ready
  */
 $time = 120;
- sleep($time);
- echo "Waking up after " . $time . " seconds";
+// sleep($time);
+echo "Waking up after " . $time . " seconds";


### PR DESCRIPTION
We don't actually need sleep, we just need the appserver to wake up. When it does succeed, we don't need to kill 2+ minutes on these scripts running.